### PR TITLE
Fix the test to check that the date is current date

### DIFF
--- a/src/__tests__/Current.test.jsx
+++ b/src/__tests__/Current.test.jsx
@@ -11,6 +11,20 @@ describe('Current', () => {
         rain: { "3h": 0 }
     }
 
+    // for testing the formatted date
+    const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+    const getDayWithOrdinalSuffix = (day) => {
+        if (day >= 11 && day <= 13) {
+            return `${day}th`;
+        }
+        switch (day % 10) {
+            case 1: return `${day}st`;
+            case 2: return `${day}nd`;
+            case 3: return `${day}rd`;
+            default: return `${day}th`;
+        }
+    };
+
     it('renders city name and weather description', () => {
         render(<Current city={cityData} />);
         const cityNameElement = screen.getByText('Tampere');
@@ -21,13 +35,17 @@ describe('Current', () => {
 
     it('renders formatted date and time', () => {
         const currentTime = new Date();
+        const month = months[currentTime.getMonth()];
+        const dayWithSuffix = getDayWithOrdinalSuffix(currentTime.getDate());
         const hours = currentTime.getHours();
         const minutes = currentTime.getMinutes();
+
+        const formattedDate = `${month} ${dayWithSuffix}`;
         const formattedMinutes = minutes < 10 ? `0${minutes}` : minutes;
         const formattedHours = hours < 10 ? `0${hours}` : hours;
 
         render(<Current city={cityData} />);
-        const dateElement = screen.getByText('March 5th');
+        const dateElement = screen.getByText(formattedDate);
         const timeElement = screen.getByText(`${formattedHours}:${formattedMinutes}`);
         expect(dateElement).toBeInTheDocument();
         expect(timeElement).toBeInTheDocument();


### PR DESCRIPTION
The test used a constant date, instead of a current date, even though the program uses a current date. Now the test also uses a current date and formats it correctly.